### PR TITLE
Fixed CMakelists.txt to avoid relative paths

### DIFF
--- a/elfin_ethercat_driver/CMakeLists.txt
+++ b/elfin_ethercat_driver/CMakeLists.txt
@@ -115,4 +115,14 @@ install(
     share/${PROJECT_NAME}
 )
 
+install(TARGETS ${PROJECT_NAME}_lib EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Export old-style CMake variables
+ament_export_include_directories("include")
+ament_export_libraries(${PROJECT_NAME}_lib)
+
 ament_package()

--- a/elfin_robot_msgs/CMakeLists.txt
+++ b/elfin_robot_msgs/CMakeLists.txt
@@ -42,4 +42,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_export_dependencies(rosidl_default_runtime)
+
 ament_package()

--- a/elfin_ros_control/CMakeLists.txt
+++ b/elfin_ros_control/CMakeLists.txt
@@ -15,14 +15,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-set(CMAKE_INSTALL_RPATH "${PROJECT_BINARY_DIR}/../elfin_ethercat_driver")
-
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in
@@ -47,8 +39,6 @@ find_package(rosidl_default_generators REQUIRED)
 
 include_directories(
   include
-  ../../../install/elfin_ethercat_driver/include
-  ../../../install/elfin_robot_msgs/include
 )
 
 set(DEPENDENCIES
@@ -64,12 +54,9 @@ set(DEPENDENCIES
   "tf2"
   "hardware_interface"
   "controller_interface"
-  "elfin_ethercat_driver"
   "pluginlib"
   "rosidl_default_generators"
 )
-
-LINK_DIRECTORIES(../../../build/elfin_ethercat_driver/)
 
 add_library(elfin_hardware_interface
         SHARED
@@ -79,10 +66,12 @@ add_library(elfin_hardware_interface
 
 target_link_libraries(
 	elfin_hardware_interface
-	libelfin_ethercat_driver_lib.so
 )
+
 target_include_directories(
         elfin_hardware_interface
+        PUBLIC
+        ${elfin_ethercat_driver_INCLUDE_DIRS}
         PRIVATE
         include
 )


### PR DESCRIPTION
I had some issue compiling the elfin ethercat driver, I noticed that the libraries was not exported, which means is not visible for other packages. That's why there are some relative paths. Same idea with the messages packages.

This PR should fix this issues.